### PR TITLE
Adding JSON serializer options to UpdateOperationsUtility.Serialize()

### DIFF
--- a/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/UpdateOperationsUtility.cs
+++ b/sdk/digitaltwins/Azure.DigitalTwins.Core/src/Serialization/UpdateOperationsUtility.cs
@@ -83,10 +83,11 @@ namespace Azure.DigitalTwins.Core.Serialization
         /// <summary>
         /// Serialize the constructed payload as json.
         /// </summary>
+        /// <param name="options">Options for JSON serializer.</param>
         /// <returns>A string of the json payload.</returns>
-        public string Serialize()
+        public string Serialize(JsonSerializerOptions options = null)
         {
-            return JsonSerializer.Serialize(_ops);
+            return JsonSerializer.Serialize(_ops, options);
         }
     }
 }


### PR DESCRIPTION
`UpdateOperationsUtility.Serialize` method takes JSON serializer options as an argument and passes them to serializer.